### PR TITLE
Fix API and LLM connection checks

### DIFF
--- a/ui/sermonaudio_api.py
+++ b/ui/sermonaudio_api.py
@@ -263,16 +263,18 @@ class SermonAudioAPI:
         return bool(self.api_key)
 
     def test_connection(self) -> bool:
-        """Test the API connection by fetching the broadcaster's speaker list."""
+        """Test the API connection by fetching the broadcaster info."""
         if not self.api_key:
             logger.warning("No API key configured for connection test")
             return False
         try:
-            import sermonaudio
-            sermonaudio.set_api_key(self.api_key)
-            from sermonaudio.node.requests import Node
-            result = Node.get_sermons(broadcaster_id=self.broadcaster_id or 'test', page=1, page_size=1)
-            return result is not None
+            import requests
+            headers = {"X-API-Key": self.api_key, "Content-Type": "application/json"}
+            resp = requests.get(
+                "https://api.sermonaudio.com/v2/node/broadcasters/self",
+                headers=headers, timeout=15
+            )
+            return resp.status_code == 200
         except Exception as e:
             logger.error("API connection test failed: %s", e)
             return False

--- a/ui/ui_pages/settings.py
+++ b/ui/ui_pages/settings.py
@@ -1638,12 +1638,17 @@ def test_llm_provider(provider, config):
         sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
         from llm_manager import LLMManager
 
-        llm_manager = LLMManager(st.session_state.get('config', {}))
+        full_config = st.session_state.get('config', {})
+        llm_manager = LLMManager(full_config)
         test_response = llm_manager.chat([{"role": "user", "content": "Reply with just: OK"}])
-        if test_response and 'OK' in str(test_response).upper():
-            st.success(f"✅ {provider.title()} provider connection successful!")
+        if test_response:
+            cleaned = str(test_response).strip().strip('"').strip("'").strip()
+            if cleaned.upper() == 'OK' or 'OK' in cleaned.upper():
+                st.success(f"✅ {provider.title()} provider connection successful!")
+            else:
+                st.warning(f"⚠️ {provider.title()} responded but unexpected: {cleaned[:100]}")
         else:
-            st.warning(f"⚠️ {provider.title()} responded but unexpected: {str(test_response)[:100]}")
+            st.error(f"❌ {provider.title()} returned empty response")
     except Exception as e:
         st.error(f"❌ {provider.title()} provider connection failed: {e}")
 


### PR DESCRIPTION
SermonAudio test_connection was using Node.get_sermons() which can silently fail. Now uses direct HTTP GET to /v2/node/broadcasters/self. LLM test now handles empty responses and strips quotes.