### PR TITLE
Release v1.5.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
     volumes:
       - sermon_data:/data
       - sermon_models:/models
-      - sermon_config:/app/config.yaml
       - sermon_output:/app/processed_sermons
       - sermon_cache:/home/sermonapp/.cache
       - sermon_logs:/app/logs
@@ -36,7 +35,6 @@ services:
 volumes:
   sermon_data:
   sermon_models:
-  sermon_config:
   sermon_output:
   sermon_cache:
   sermon_logs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     volumes:
       - sermon_data:/data
       - sermon_models:/models
+      - sermon_api_cache:/app/api_cache
       - sermon_output:/app/processed_sermons
       - sermon_cache:/home/sermonapp/.cache
       - sermon_logs:/app/logs
@@ -35,6 +36,7 @@ services:
 volumes:
   sermon_data:
   sermon_models:
+  sermon_api_cache:
   sermon_output:
   sermon_cache:
   sermon_logs:

--- a/ui/ui_pages/new_sermon_enhanced.py
+++ b/ui/ui_pages/new_sermon_enhanced.py
@@ -140,14 +140,14 @@ def _show_processing_section():
         transcribe = st.checkbox("Transcribe Audio", key="transcribe", value=True,
                                  help="Generate transcript from the audio")
         if transcribe:
-            transcription_backend = st.radio(
-                "Backend", key="transcription_backend",
+            transcription_backend_label = st.radio(
+                "Backend", key="transcription_backend_radio",
                 options=["Faster Whisper (Local)", "OpenAI Whisper API"],
                 index=0, horizontal=True,
                 help="Faster Whisper (local, CTranslate2) or OpenAI API"
             )
-            transcription_backend = "faster_whisper_local" if transcription_backend == "Faster Whisper (Local)" else "whisper_openai"
-            st.session_state.transcription_backend = transcription_backend
+            transcription_backend = "faster_whisper_local" if transcription_backend_label == "Faster Whisper (Local)" else "whisper_openai"
+            st.session_state.selected_backend = transcription_backend
             if transcription_backend == "whisper_openai":
                 _show_openai_whisper_ui()
             else:
@@ -370,7 +370,7 @@ def start_enhanced_processing():
             'skip_transcription': not transcribe,
             'skip_ai_generation': not generate_ai,
             'whisper_model': st.session_state.get('whisper_model', 'large'),
-            'transcription_backend': st.session_state.get('transcription_backend', 'whisper_local'),
+            'transcription_backend': st.session_state.get('selected_backend', 'faster_whisper_local'),
             'enhancement_method': st.session_state.get('enhancement_method', 'deepfilternet'),
             'custom_repo': st.session_state.get('custom_repo', ''),
             'custom_file': st.session_state.get('custom_file', ''),
@@ -411,6 +411,7 @@ def reset_enhanced_form():
         'sermon_title', 'sermon_subtitle', 'sermon_description', 'sermon_hashtags',
         'sermon_series', 'enhance_audio', 'transcribe', 'enhancement_method',
         'transcription_backend', 'whisper_model', 'custom_repo', 'custom_file',
+        'selected_backend',
         'generate_title', 'generate_description', 'generate_hashtags',
         'validate_description', 'generate_short_title', 'dry_run',
     ]


### PR DESCRIPTION
## v1.5.3

### Bug Fixes
- **Docker**: Install git in Docker image (required by DeepFilterNet's `df.io.py` which calls `get_git_root()`)
- **Transcription backend mapping**: Fix incorrect backend name mapping in Docker startup
- **API/LLM connection checks**: Fix false positives — `SermonAudioAPI.test_connection()` now uses direct HTTP GET to `/v2/node/broadcasters/self`; LLM test handles empty responses and strips quotes
- **Streamlit session_state conflict**: Use separate key for radio widget vs internal value in transcription backend selector
- **Docker volumes**: Fix config volume type (named volumes are directories, not files); add persistent volumes for `api_cache`, `processed_sermons`, and model cache

### Features
- **Data persistence**: Add persistent Docker volumes (`sermon_data`, `sermon_api_cache`, `sermon_output`, `sermon_cache`, `sermon_logs`) so DB, API cache, and processed output survive container restarts
- **Release process**: Add GitHub Release creation step to AGENTS.md release workflow

### Chores
- Bump version 1.5.2 → 1.5.3
- Update AGENTS.md: document branch + PR workflow, direct commits to master not allowed