### PR TITLE
fix: status checks - DFN compat shim, correct API probe endpoint (wayfinder/TKT-44)

### DIFF
--- a/ui/sermonaudio_api.py
+++ b/ui/sermonaudio_api.py
@@ -264,15 +264,17 @@ class SermonAudioAPI:
 
     def test_connection(self) -> bool:
         """Test the API connection by fetching the broadcaster info."""
-        if not self.api_key:
-            logger.warning("No API key configured for connection test")
+        if not self.api_key or not self.broadcaster_id:
+            logger.warning("No API key or broadcaster ID configured for connection test")
             return False
         try:
             import requests
-            headers = {"X-API-Key": self.api_key, "Content-Type": "application/json"}
+            headers = {"X-Api-Key": self.api_key, "Content-Type": "application/json"}
             resp = requests.get(
-                "https://api.sermonaudio.com/v2/node/broadcasters/self",
-                headers=headers, timeout=15
+                "https://api.sermonaudio.com/v2/node/sermons",
+                headers=headers,
+                params={"broadcasterID": self.broadcaster_id, "pageSize": 1, "lite": "true"},
+                timeout=15,
             )
             return resp.status_code == 200
         except Exception as e:

--- a/ui/system_status.py
+++ b/ui/system_status.py
@@ -346,7 +346,13 @@ class SystemStatusManager:
             # Check if required packages are available
             if method == 'deepfilternet':
                 try:
-                    import df  # DeepFilterNet uses 'df' package name
+                    # The torchaudio compat shim must run before importing df:
+                    # df imports torchaudio.backend.common.AudioMetaData which
+                    # newer torchaudio versions removed.
+                    from audio_processing import _ensure_torchaudio_backend_compat
+                    _ensure_torchaudio_backend_compat()
+                    import df  # DeepFilterNet pip package provides 'df' module
+                    from df import enhance as _df_enhance, init_df as _df_init
                     return {
                         'status': 'ok',
                         'message': 'DeepFilterNet ready',


### PR DESCRIPTION
Part of #43. Release v1.6.0.

- check_audio_enhancement runs the torchaudio compat shim before importing df (fixes false 'DeepFilterNet not installed')
- test_connection probes GET /v2/node/sermons with broadcasterID (fixes false 'API connection failed' on the nonexistent broadcasters/self endpoint)