### PR TITLE
fix: int-convert duration parts in _format_duration (float :02d crash) (TKT-49)

### DIFF
--- a/ui/ui_pages/library.py
+++ b/ui/ui_pages/library.py
@@ -891,8 +891,8 @@ def _format_duration(seconds):
     hours, remainder = divmod(seconds, 3600)
     minutes, secs = divmod(remainder, 60)
     if hours > 0:
-        return f"{hours}:{minutes:02d}:{secs:02d}"
-    return f"{minutes}:{secs:02d}"
+        return f"{int(hours)}:{int(minutes):02d}:{int(secs):02d}"
+    return f"{int(minutes):02d}:{int(secs):02d}"
 
 def display_sermon_details(sermon):
     """Display detailed sermon information with API data"""


### PR DESCRIPTION
Verification found the duration formatter crashed on float seconds ('Unknown format code d for object of type float') — the library list showed an error alert per row. Int-converts the parts. Follow-up to #117 (merged before this fix landed). Part of #45. Release v1.6.0 (#31).