### PR TITLE
fix: library list column widths for text status and View button

### DIFF
--- a/ui/ui_pages/library.py
+++ b/ui/ui_pages/library.py
@@ -617,7 +617,7 @@ def show_library():
                 )
 
         # Main layout with two columns
-        col_list, col_detail = st.columns([2, 3])
+        col_list, col_detail = st.columns([3, 2])
 
         with col_list:
             st.markdown("### Sermons")


### PR DESCRIPTION
The text labels still wrapped at the list's 384px width (2/5 split favors the details panel). Rebalanced the split to [3, 2] so the list column is ~580px: status, duration, and View now fit on one line. Part of #45. Release v1.6.0 (#31).