### PR TITLE
ui: remove top gap, add sidebar section dividers

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -202,6 +202,30 @@ st.markdown("""
         gap: 0.2rem;
     }
 
+    /* Pull the page content up under the header bar */
+    [data-testid="stMainBlockContainer"] {
+        padding-top: 1.5rem;
+    }
+
+    /* Sidebar: divide the nav from the status and actions sections */
+    [data-testid="stSidebarNav"] {
+        border-bottom: 1px solid var(--surface-border);
+        padding-bottom: 0.75rem;
+        margin-bottom: 0.25rem;
+    }
+
+    [data-testid="stSidebar"] [data-testid="stExpander"] {
+        border-top: 1px solid var(--surface-border);
+        margin-top: 0.5rem;
+        padding-top: 0.5rem;
+    }
+
+    [data-testid="stSidebar"] h3 {
+        border-top: 1px solid var(--surface-border);
+        margin-top: 0.5rem;
+        padding-top: 0.5rem;
+    }
+
     /* Hide the Streamlit skills promo banner */
     [data-testid="stSkillsNudgeAnchor"] {
         display: none !important;


### PR DESCRIPTION
Two layout fixes from feedback: (1) the main content had Streamlit's default ~6rem top padding (content started at y=112) - now 1.5rem (y=40). (2) The sidebar was plain text with no structure - added thin dividers under the nav menu and between System Status and Quick Actions, themed for light+dark. Vision-verified 5/5 in both modes. Part of #45. Release v1.6.0 (#31).