### PR TITLE
ci: release tag job drafts the release and triggers the docker build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -53,9 +53,12 @@ jobs:
 
       - name: Extract version
         id: version
+        # Any v-tag ref counts as a release build, including a
+        # workflow_dispatch on the tag (release.yml dispatches the build
+        # after cutting the tag, since token-pushed refs fire no events).
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
             echo "publish_moving=true" >> "$GITHUB_OUTPUT"
           else
             echo "tag=$(date +%Y%m%d%H%M%S)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,10 @@ name: Release
 
 # Releases are cut by CI so a merged version bump can never ship untagged:
 # release PRs are checked against the tags, a push to master creates the
-# missing annotated tag, and the tag push drafts the GitHub Release.
+# missing annotated tag, then drafts the GitHub Release and dispatches the
+# docker build from that same job (refs pushed with GITHUB_TOKEN fire no
+# push events). Manually pushed tags still get validated and drafted by
+# the tag-push job below.
 # Actions are pinned to commit SHAs of their release tags to prevent
 # supply-chain tampering; the tag is noted in a trailing comment.
 
@@ -88,12 +91,14 @@ jobs:
 
   create-release-tag:
     # After a release PR merges to master, creates the annotated tag for the
-    # pyproject.toml version when it is not tagged yet. The tag push triggers
-    # this workflow's draft job and the docker build workflow.
+    # pyproject.toml version when it is not tagged yet. Token-pushed refs
+    # fire no push events, so this job also drafts the release and dispatches
+    # the docker build on the tag ref.
     if: github.event_name == 'push' && github.ref_name == 'master'
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
 
     steps:
       - name: Checkout code
@@ -108,12 +113,18 @@ jobs:
           python-version: '3.11'
 
       - name: Create annotated tag when the version is not yet tagged
+        id: tag
         run: |
           python - <<'EOF'
+          import os
           import re
           import subprocess
           import sys
           import tomllib
+
+          def emit(key, value):
+              with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                  f.write(f"{key}={value}\n")
 
           with open("pyproject.toml", "rb") as f:
               version = tomllib.load(f)["project"]["version"]
@@ -146,13 +157,32 @@ jobs:
           run("git", "config", "user.email", "github-actions[bot]@users.noreply.github.com")
           run("git", "tag", "-a", tag, "-m", f"{tag}: release cut by CI (wayfinder/TKT-62)")
           run("git", "push", "origin", tag)
+          emit("tag", tag)
+          emit("created", "true")
           print(f"created and pushed annotated tag {tag}")
           EOF
 
+      - name: Draft the release and dispatch the docker build
+        if: steps.tag.outputs.created == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            gh release create "$TAG" --draft --generate-notes --title "$TAG" --target "$GITHUB_SHA"
+            echo "drafted release $TAG"
+          else
+            echo "release $TAG already exists; skipping draft"
+          fi
+          gh workflow run docker-build.yml --ref "$TAG"
+          echo "dispatched docker-build.yml on $TAG"
+
   draft-github-release:
-    # Runs on the tag push: validates the tag against pyproject.toml, then
-    # drafts the GitHub Release with auto-generated notes. The docker build
-    # workflow runs from the same tag in parallel; publish the draft once
+    # Runs on tag pushes (manual cuts): validates the tag against
+    # pyproject.toml, then drafts the GitHub Release with auto-generated
+    # notes unless a draft already exists. CI-cut tags arrive with a draft
+    # already created by create-release-tag, so this skips gracefully.
+    # The docker build runs from the same tag; publish the draft once
     # the build succeeds.
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,9 +114,10 @@ Direct commits to `master` are **not allowed**. Every change must go through a b
 
 - `.github/workflows/release.yml` covers the release flow end to end:
   - **On release PRs** (branch `release/vX.Y.Z`, touching `pyproject.toml`): fails unless the version is a valid `MAJOR.MINOR.PATCH` bump above the latest tag, the tag does not exist yet, and the branch name matches the version
-  - **On merge to master**: creates the annotated tag `vX.Y.Z` when the pyproject.toml version is not yet tagged
-  - **On tag push**: validates the tag against `pyproject.toml`, then drafts the GitHub Release with auto-generated notes
-- The tag push triggers `.github/workflows/docker-build.yml` (tags `v*`) to build and push the `cuda`/`rocm`/`cpu` images from the tag; the release draft is published manually after the build succeeds
+  - **On merge to master**: creates the annotated tag `vX.Y.Z` when the pyproject.toml version is not yet tagged, then drafts the GitHub Release with auto-generated notes and dispatches `.github/workflows/docker-build.yml` on the tag ref (refs pushed with GITHUB_TOKEN fire no push events, so the tag push alone would trigger nothing)
+  - **On tag push**: validates the tag against `pyproject.toml`, then drafts the GitHub Release with auto-generated notes unless a draft already exists; this path covers manually pushed tags
+- `.github/workflows/docker-build.yml` builds and pushes the `cuda`/`rocm`/`cpu` images from any `v*` tag ref, whether pushed or dispatched on the tag: versioned tags plus the moving per-backend and `latest` tags. Plain branch dispatches produce timestamp-only tags
+- The release draft is published manually after the Docker build succeeds
 - The checks exist so a merged version bump can never ship untagged again
 
 ### Tag Naming


### PR DESCRIPTION
Fixes #136. The auto-tag job now drafts the release and dispatches docker-build onto the tag ref (workflow-created tags fire no push events, so the Docker images and release draft never materialized - hit during the v1.6.0 cut). docker-build treats any refs/tags/v* ref as a release build; duplicate-draft guards on both paths; manual tag pushes unchanged. AGENTS.md Release Automation updated. Part of #47.