### PR TITLE
feat: auto-detect title, series, speaker, date from the uploaded filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Segments are positional, split on the literal `" - "` separator, and anything pa
 | 3 | Speaker | Speaker dropdown (selects an existing pastor, otherwise pre-fills "Add New") | Left empty |
 | 4 | Date | Recording Date; accepts `YYYY-MM-DD`, `YYYY_MM_DD`, `MM-DD-YYYY`, `MM_DD_YYYY`, `DD.MM.YYYY` | Stays at today's default |
 
-Detection runs once per uploaded filename and only fills fields you have left empty, so your own edits are never overwritten.
+Detection runs once per uploaded filename and only fills fields still at their defaults, so your own edits are never overwritten.
 
 Examples:
 - `My Sermon - Romans - Paul - 2026-08-20.mp4` fills title "My Sermon", series "Romans", speaker "Paul" and date 2026-08-20

--- a/README.md
+++ b/README.md
@@ -121,6 +121,29 @@ streamlit run streamlit_app.py
 # Open http://localhost:8501
 ```
 
+#### Filename auto-detection
+
+When you upload a file on the **New Sermon** page, SermonPilot reads the filename and pre-fills the metadata form. Name your recordings:
+
+```
+Title - Series - Speaker - date.extension
+```
+
+Segments are positional, split on the literal `" - "` separator, and anything past the fourth segment is ignored.
+
+| Position | Segment | Fills | If missing |
+|----------|---------|-------|------------|
+| 1 | Title | Sermon Title | Left blank for AI generation |
+| 2 | Series | Series dropdown (selects an existing series, otherwise pre-fills "Add New") | Left empty |
+| 3 | Speaker | Speaker dropdown (selects an existing pastor, otherwise pre-fills "Add New") | Left empty |
+| 4 | Date | Recording Date; accepts `YYYY-MM-DD`, `YYYY_MM_DD`, `MM-DD-YYYY`, `MM_DD_YYYY`, `DD.MM.YYYY` | Stays at today's default |
+
+Detection runs once per uploaded filename and only fills fields you have left empty, so your own edits are never overwritten.
+
+Examples:
+- `My Sermon - Romans - Paul - 2026-08-20.mp4` fills title "My Sermon", series "Romans", speaker "Paul" and date 2026-08-20
+- `Evening Prayer.mp4` fills only the title "Evening Prayer"
+
 ### CLI — New Sermon
 ```bash
 python sermon_updater.py new-sermon audio.mp3 --speaker "Pastor Smith" --date "2024-01-15"

--- a/tests/test_filename_autodetect.py
+++ b/tests/test_filename_autodetect.py
@@ -1,0 +1,75 @@
+"""Tests for filename metadata auto-detection parsing."""
+
+from datetime import date
+
+from ui.sermon_metadata import parse_sermon_filename
+
+
+def test_full_format():
+    parsed = parse_sermon_filename("My Sermon - Romans - Paul - 2026-08-20.mp4")
+    assert parsed == {
+        "title": "My Sermon",
+        "series": "Romans",
+        "speaker": "Paul",
+        "date": date(2026, 8, 20),
+    }
+
+
+def test_title_only():
+    parsed = parse_sermon_filename("Evening Prayer.mp4")
+    assert parsed["title"] == "Evening Prayer"
+    assert parsed["series"] is None
+    assert parsed["speaker"] is None
+    assert parsed["date"] is None
+
+
+def test_title_and_series():
+    parsed = parse_sermon_filename("Sermon - Galatians.mp3")
+    assert parsed["title"] == "Sermon"
+    assert parsed["series"] == "Galatians"
+    assert parsed["speaker"] is None
+    assert parsed["date"] is None
+
+
+def test_missing_date_keeps_positions():
+    parsed = parse_sermon_filename("T -  - Paul - .mp4")
+    assert parsed["title"] == "T"
+    assert parsed["series"] is None
+    assert parsed["speaker"] == "Paul"
+    assert parsed["date"] is None
+
+
+def test_more_than_four_segments_ignores_extras():
+    parsed = parse_sermon_filename("A - B - C - 2026-01-02 - extra.mp4")
+    assert parsed["title"] == "A"
+    assert parsed["series"] == "B"
+    assert parsed["speaker"] == "C"
+    assert parsed["date"] == date(2026, 1, 2)
+
+
+def test_date_formats():
+    assert parse_sermon_filename("A - B - C - 2026_08_20.mp3")["date"] == date(2026, 8, 20)
+    assert parse_sermon_filename("A - B - C - 08-20-2026.mp3")["date"] == date(2026, 8, 20)
+    assert parse_sermon_filename("A - B - C - 8_20_2026.mp3")["date"] == date(2026, 8, 20)
+
+
+def test_invalid_dates_left_alone():
+    for name in (
+        "A - B - C - 2026-02-30.mp3",
+        "A - B - C - 13-13-2026.mp3",
+        "A - B - C - not-a-date.mp3",
+    ):
+        assert parse_sermon_filename(name)["date"] is None
+
+
+def test_segments_are_stripped():
+    parsed = parse_sermon_filename("  Spaced Title  -  Series X  -  Speaker  - 2026-08-20.mp3")
+    assert parsed["title"] == "Spaced Title"
+    assert parsed["series"] == "Series X"
+    assert parsed["speaker"] == "Speaker"
+
+
+def test_no_separator_title_only():
+    parsed = parse_sermon_filename("My Sermon.mp3")
+    assert parsed["title"] == "My Sermon"
+    assert parsed["series"] is None

--- a/ui/sermon_metadata.py
+++ b/ui/sermon_metadata.py
@@ -492,3 +492,108 @@ def create_series_selectbox(
     else:
         st.session_state[f"{key}_id"] = series_map.get(selected)
         return selected
+
+
+_FILENAME_DATE_FORMATS = ('%Y-%m-%d', '%Y_%m_%d', '%m-%d-%Y', '%m_%d_%Y', '%d.%m.%Y')
+
+
+def parse_sermon_filename(filename: str) -> dict[str, str | datetime.date | None]:
+    """Parse 'Title - Series - Speaker - date.ext' style filenames.
+
+    The stem is split on the literal ' - ' separator: position 0 is the title,
+    1 the series, 2 the speaker and 3 a date candidate. Segments past the
+    fourth are ignored and missing ones come back as None.
+    """
+    stem = Path(filename).stem
+    segments = [segment.strip() for segment in stem.split(' - ')]
+
+    def segment(index: int) -> str | None:
+        return segments[index] if index < len(segments) else None
+
+    raw_date = segment(3)
+    return {
+        'title': segment(0) or None,
+        'series': segment(1) or None,
+        'speaker': segment(2) or None,
+        'date': _parse_filename_date(raw_date) if raw_date else None,
+    }
+
+
+def _parse_filename_date(value: str) -> datetime.date | None:
+    for date_format in _FILENAME_DATE_FORMATS:
+        try:
+            return datetime.datetime.strptime(value, date_format).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _match_option(options: list[str], value: str) -> str | None:
+    for option in options:
+        if option == value:
+            return option
+    folded = value.casefold()
+    for option in options:
+        if option.casefold() == folded:
+            return option
+    return None
+
+
+def _speaker_field_set() -> bool:
+    selected = st.session_state.get('speaker_name_select')
+    if selected and selected not in ('[Select Pastor]', '[Add New Pastor]'):
+        return True
+    return bool(st.session_state.get('speaker_name_custom'))
+
+
+def _series_field_set() -> bool:
+    selected = st.session_state.get('sermon_series_select')
+    if selected and selected not in ('[No Series]', '[Add New Series]'):
+        return True
+    return bool(st.session_state.get('sermon_series_custom'))
+
+
+def apply_filename_autodetect(filename: str) -> bool:
+    """Pre-fill metadata fields from an uploaded filename.
+
+    Call before the metadata widgets render. Only fields the user has not set
+    are touched. Returns True when any field was pre-filled.
+    """
+    parsed = parse_sermon_filename(filename)
+    applied = False
+
+    title = parsed['title']
+    if title and not st.session_state.get('sermon_title'):
+        st.session_state['sermon_title'] = title
+        applied = True
+
+    speaker = parsed['speaker']
+    if speaker and not _speaker_field_set():
+        match = _match_option(get_pastors(), speaker)
+        if match is not None:
+            st.session_state['speaker_name_select'] = match
+        else:
+            st.session_state['speaker_name_select'] = '[Add New Pastor]'
+            st.session_state['speaker_name_custom'] = speaker
+        applied = True
+
+    series = parsed['series']
+    if series and not _series_field_set():
+        match = _match_option(get_series(), series)
+        if match is not None:
+            st.session_state['sermon_series_select'] = match
+            st.session_state['sermon_series_id'] = get_series_map().get(match)
+        else:
+            st.session_state['sermon_series_select'] = '[Add New Series]'
+            st.session_state['sermon_series_custom'] = series
+            st.session_state['sermon_series_id'] = None
+        applied = True
+
+    parsed_date = parsed['date']
+    if parsed_date is not None:
+        current_date = st.session_state.get('recorded_date')
+        if current_date is None or current_date == datetime.date.today():
+            st.session_state['recorded_date'] = parsed_date
+            applied = True
+
+    return applied

--- a/ui/ui_pages/new_sermon_enhanced.py
+++ b/ui/ui_pages/new_sermon_enhanced.py
@@ -525,7 +525,7 @@ def start_enhanced_processing():
 
 def reset_enhanced_form():
     keys_to_clear = [
-        'uploaded_file', 'metadata_complete',
+        'uploaded_file', 'metadata_complete', 'autodetected_filename',
         'speaker_name_select', 'speaker_name_custom',
         'recorded_date', 'event_type_select', 'event_type_custom', 'bible_text',
         'sermon_title', 'sermon_subtitle', 'sermon_description', 'sermon_hashtags',

--- a/ui/ui_pages/new_sermon_enhanced.py
+++ b/ui/ui_pages/new_sermon_enhanced.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(project_root / "ui"))
 sys.path.insert(0, str(project_root / "src"))
 
 from ui.sermon_metadata import (  # noqa: E402
+    apply_filename_autodetect,
     create_event_type_selectbox,
     create_pastor_selectbox,
     create_series_selectbox,
@@ -55,6 +56,10 @@ def _show_upload_section():
 
     if uploaded_file:
         st.session_state.uploaded_file = uploaded_file
+
+        if st.session_state.get('autodetected_filename') != uploaded_file.name:
+            apply_filename_autodetect(uploaded_file.name)
+            st.session_state.autodetected_filename = uploaded_file.name
 
         col1, col2, col3, col4 = st.columns(4)
         with col1:


### PR DESCRIPTION
Fixes #137. Uploading a file named `Title - Series - Speaker - date.ext` pre-fills the New Sermon form: positional segments map to title/series/speaker/date; missing segments leave their fields untouched; only unset fields are filled; parses once per filename (reruns never clobber edits); speaker/series match existing options case-insensitively or take the Add-New path with consistent series_id handling. Documented in README. Verified via AppTest (49 checks) + live upload. Part of #45.