### PR TITLE
fix: auth gate enforced per request (was bypassed after first session)

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -56,7 +56,7 @@ from ui.pages import (  # noqa: E402
     settings,
     validation,
 )
-from ui.shared_navigation import render_sidebar_extras  # noqa: E402
+from ui.shared_navigation import enforce_authentication, render_sidebar_extras  # noqa: E402
 
 # Configure Streamlit page
 st.set_page_config(
@@ -339,6 +339,7 @@ def _dashboard_landing():
 
 def main():
     """Main application entry point"""
+    enforce_authentication()
     initialize_session_state()
 
     if not st.session_state.config:

--- a/ui/shared_navigation.py
+++ b/ui/shared_navigation.py
@@ -17,9 +17,12 @@ sys.path.insert(0, str(project_root))
 sys.path.insert(0, str(project_root / "src"))
 sys.path.insert(0, str(ui_dir))
 
-if not is_authenticated():
-    render_login()
-    st.stop()
+
+def enforce_authentication() -> None:
+    """Gate every script run: unauthenticated sessions get only the login form."""
+    if not is_authenticated():
+        render_login()
+        st.stop()
 
 
 def _status_class(label: str) -> str:


### PR DESCRIPTION
Fixes AUDIT-057: the APP_PASSWORD gate ran at module import, so sys.modules caching meant only the FIRST browser session saw the login. The gate now runs per request in main() (enforce_authentication), verified live: fresh session 1 gated -> wrong password rejected -> correct password renders app; fresh session 2 also gated. Part of #45.