### PR TITLE
fix: docker build context leaks 7GB; CUDA torch at version floor

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,13 @@
 # .dockerignore
 .git
 .gitignore
+.github/
+.githooks/
 README.md
 .env
 .venv/
 .venv-*/
+.venv.old/
 venv/
 env/
 __pycache__/
@@ -13,6 +16,7 @@ __pycache__/
 *.so
 .mypy_cache/
 .pytest_cache/
+.ruff_cache/
 .coverage
 .tox/
 .cache
@@ -45,6 +49,7 @@ test_*/
 *.db
 api_cache/
 analytics_cache/
+analytics_vector_db/
 
 # Documentation and plans
 docs/
@@ -66,7 +71,9 @@ Thumbs.db
 # Temporary files
 *.tmp
 *.temp
+.tmp/
 .cache/
+audit-*.png
 
 # Test files
 tests/
@@ -77,3 +84,7 @@ conftest.py
 
 # Agent files
 AGENTS.md
+.agents/
+.claude/
+.playwright-mcp/
+opencode.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG GPU_BACKEND=cpu
 
 FROM ubuntu:22.04 AS base-cpu
 
-FROM nvidia/cuda:12.1.1-runtime-ubuntu22.04 AS base-cuda
+FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04 AS base-cuda
 
 FROM rocm/dev-ubuntu-22.04:7.1 AS base-rocm
 
@@ -43,14 +43,7 @@ RUN pip install --no-cache-dir uv
 
 # Install core + GPU-specific dependencies
 RUN if [ "$GPU_BACKEND" = "cuda" ]; then \
-        grep -v '^onnxruntime' requirements/requirements.txt > /tmp/requirements-cuda.txt && \
-        uv pip install --no-cache-dir -r /tmp/requirements-cuda.txt && \
-        uv pip install --no-cache-dir \
-            --index-url https://download.pytorch.org/whl/cu121 \
-            --reinstall-package torch \
-            --reinstall-package torchaudio \
-            --reinstall-package torchvision \
-            torch torchaudio torchvision && \
+        uv pip install --no-cache-dir -r requirements/requirements-gpu.txt && \
         uv pip install --no-cache-dir "onnxruntime-gpu>=1.22.1"; \
     elif [ "$GPU_BACKEND" = "rocm" ]; then \
         uv pip install --no-cache-dir -r requirements/requirements-rocm.txt; \


### PR DESCRIPTION
Fixes AUDIT-003 and AUDIT-012: .dockerignore now excludes .venv.old (7GB), analytics_vector_db, .playwright-mcp, .ruff_cache, .tmp, .agents, .claude, .githooks, opencode.json, audit-*.png, .github. CUDA stage bumped to nvidia/cuda:12.4.1-runtime-ubuntu22.04 and installs requirements-gpu.txt (torch==2.6.0+cu124) instead of the cu121 grep/reinstall dance that shipped torch 2.5.1 below the declared floor. Part of #45.