### PR TITLE
fix: guaranteed crash bugs - hashtags coercion, status SQL, DFN retry rate

### DIFF
--- a/sermon_updater.py
+++ b/sermon_updater.py
@@ -987,11 +987,16 @@ def validate_and_regenerate_descriptions(
     }
 
 
-def update_sermon_metadata(sermon_id: str, description: str, hashtags: str | list[str],
+def update_sermon_metadata(sermon_id: str, description: str, hashtags: str | list[str] | None,
                           series_title: str = None, series_id: int | None = None) -> bool:
     url = BASE_URL + f'node/sermons/{sermon_id}'
     headers = get_api_headers()
-    keywords = hashtags if isinstance(hashtags, str) else ','.join(hashtags)
+    if hashtags is None:
+        keywords = ""
+    elif isinstance(hashtags, (list, tuple)):
+        keywords = ','.join(str(tag) for tag in hashtags)
+    else:
+        keywords = str(hashtags)
     payload = {'moreInfoText': description, 'keywords': keywords}
     if series_id is None and series_title:
         series_id = resolve_series_id(series_title)

--- a/src/audio_processing.py
+++ b/src/audio_processing.py
@@ -911,9 +911,22 @@ class AudioProcessor:
             try:
                 logger.info("Retrying DeepFilterNet with chunked processing")
                 chunk_seconds = 30
-                return self.process_large_audio_in_chunks(
-                    audio_for_fallback, original_sample_rate, chunk_size_seconds=chunk_seconds
+                result = self.process_large_audio_in_chunks(
+                    audio_data, sample_rate, chunk_size_seconds=chunk_seconds
                 )
+                if sample_rate != original_sample_rate:
+                    logger.info(
+                        f"Resampling chunked retry result from {sample_rate} Hz "
+                        f"back to {original_sample_rate} Hz"
+                    )
+                    res_t = torch.from_numpy(result.astype(np.float32)).contiguous()
+                    if res_t.ndim == 1:
+                        res_t = res_t.unsqueeze(0)
+                    res_t = torchaudio.functional.resample(res_t, 48000, original_sample_rate)
+                    result = res_t.squeeze(0).numpy() if res_t.shape[0] == 1 else res_t.numpy()
+                    if result.ndim == 1 and result.shape[0] == 1:
+                        result = result[0]
+                return result
             except Exception as e2:
                 logger.error(f"DeepFilterNet chunked processing also failed: {e2}")
                 logger.warning("Falling back to custom noise reduction")

--- a/ui/database.py
+++ b/ui/database.py
@@ -441,9 +441,8 @@ class SermonDatabase:
                 conn.execute("""
                     UPDATE processing_status
                     SET status = ?, progress = ?, message = ?, updated_at = ?,
-                        completed_at = (
-                            "CASE WHEN ? IN ('completed', 'failed') THEN ? ELSE completed_at END"
-                        )
+                        completed_at = CASE WHEN ? IN ('completed', 'failed')
+                                        THEN ? ELSE completed_at END
                     WHERE id = ?
                 """, (status, progress, message, now, status, now, existing['id']))
             else:


### PR DESCRIPTION
Fixes #141 findings: (1) regenerated descriptions never uploaded - update_sermon_metadata now coerces None/list hashtags safely; (2) update_processing_status raised ProgrammingError on every second write (SQL CASE in double quotes) - rewritten as real parameterized SQL, reproduced fixed; (3) DeepFilterNet failure retry fed 44.1kHz into a 48kHz chunk processor - retry stays at 48kHz. Part of #45.