### PR TITLE
fix: db/jobs integrity - WAL mode, retention, indexes, FTS sanitize

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,63 +1,44 @@
-# TKT-154 progress: CI supply chain and caching
+# TKT-145/146/159 Progress — db/jobs integrity
 
-Branch: fix/ci-supply-chain (base = master 1aff3c5)
+Branch: fix/db-jobs-integrity (base origin/master 393463a)
+Worktree: /tmp/opencode/wt-cfg
 
-## Done
+- [x] TKT-145: transcript stripped at persistence (`_result_for_persistence`) and at source (executor trims key)
+- [x] TKT-145: llm_api_usage pruned by cleanup_old_records (days param)
+- [x] TKT-145: Clear Completed also removes FAILED; prune_old_jobs(30d) runs at queue start
+- [x] TKT-146: WAL pragma at database init
+- [x] TKT-146: SQLite writes moved out of queue lock (add_job, _get_next_job, cancel_job, retry_job, _recover_orphaned_jobs, clear_completed_jobs)
+- [x] TKT-159: UTC timestamps: `utcnow()` helper; all 21 local now() DB writes/comparisons in database.py are UTC (naive format keeps parity with legacy rows)
+- [x] TKT-159: FTS5 MATCH input sanitization (`sanitize_fts_query`, quoted tokens, empty input returns [])
+- [x] TKT-159: 6 indexes added in init_database
+- [x] TKT-159: favorite/notes updates skip FTS rebuild (update_sermon_metadata rebuilds only when title/speaker/content changed)
+- [x] Run test suite + ruff, verify WAL takes effect
 
-- Read docker-build.yml: five floating refs found (checkout@v4, setup-buildx@v3,
-  login-action@v3 x2 jobs, build-push@v6).
-- Collected repo's pinned-SHA convention from ci.yml / release.yml / security-check.yml:
-  - actions/checkout @ 11bd71901bbe5b1630ceea73d27597364c9af683 (v4.2.2)
-  - actions/setup-python @ 42375524e23c412d93fb67b49958b491fce71c38 (v5.4.0)
-  - actions/upload-artifact @ b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 (v4.4.3)
-- Docker actions absent elsewhere in repo, so verified latest tags via GitHub API
-  (all resolved objects are type=commit):
-  - docker/setup-buildx-action v3.12.0 -> 8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
-  - docker/login-action v3.7.0 -> c94ce9fb468520275223c153574b00df6fe4bcc9
-  - docker/build-push-action v6.19.2 -> 10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+## TKT-159 UTC decision
 
-## AUDIT-014 analysis (minimal dep set)
+All new explicit writes use naive UTC (`utcnow()`), matching the
+`CURRENT_TIMESTAMP` (UTC) defaults that already populate created_at columns
+and llm_api_usage.timestamp. This fixes the clearly-wrong comparisons:
+get_llm_usage_summary/get_llm_usage_by_operation compared a local-time
+cutoff against UTC-stored rows, excluding recent rows by the UTC offset.
+Legacy rows written with local time keep their stored values; for cache
+expiry and pruning they are now off by the timezone offset at worst, which
+is safer than the previous mixed comparison. No data migration performed.
 
-Module-level import trace for the fast suite:
-- sermon_updater.py top level: stdlib + requests + dotenv(load_dotenv) +
-  sermonaudio (stubbed by conftest) + src.sermon_paths (stdlib) + lazy
-  cli.parser/core.config/llm_manager/processing.orchestrator/transcription ->
-  core.config needs yaml; llm_manager+transcription need requests;
-  audio_processing import is try/except guarded (no torch needed).
-- ui.database, ui.sermonaudio_analytics: stdlib + requests.
-- ui.sermon_metadata: needs streamlit (unguarded module-level import).
-- Minimal set: pytest, ruff, requests, python-dotenv, PyYAML, streamlit.
+## Verification (32/32 ad-hoc checks, /tmp/opencode/verify_dbjobs.py)
 
-Proof: clean venv (/tmp/opencode/ci-min-venv) with only those packages ->
-ruff check . passes; pytest -m "not heavy" -> 30 passed, 0.28s.
-No manifest files touched.
-
-## Changes
-
-- [x] docker-build.yml: pin all five refs, add ci.yml-style pinning comment.
-- [x] ci.yml: setup-python cache: 'pip' keyed on requirements/requirements.txt;
-      fast job installs the verified minimal set instead of full requirements.
-- [x] Validate both files parse (python yaml.safe_load).
-- [x] Prove CI sequence in clean venv: minimal install -> pip install -e .
-      --no-deps (hatchling, build isolation) -> ruff check . -> 30 passed.
-- [ ] Commit.
-
-## Final pins in docker-build.yml
-
-| Action | SHA | Tag |
-|---|---|---|
-| actions/checkout | 11bd71901bbe5b1630ceea73d27597364c9af683 | v4.2.2 (repo convention) |
-| docker/setup-buildx-action | 8d2750c68a42422c14e847fe6c8ac0403b4cbd6f | v3.12.0 (latest v3) |
-| docker/login-action | c94ce9fb468520275223c153574b00df6fe4bcc9 | v3.7.0 (latest v3, both jobs) |
-| docker/build-push-action | 10e90e3645eae34f1e60eeb005ba3a3d33f178e8 | v6.19.2 (latest v6) |
-
-## Cache key config (ci.yml)
-
-```yaml
-cache: 'pip'
-cache-dependency-path: requirements/requirements.txt
-```
-
-Fast job installs: ruff pytest requests python-dotenv PyYAML streamlit,
-plus `pip install -e . --no-deps`.
-
+- WAL: fresh sqlite3 connection reports journal_mode=wal; migrate_db copy too
+- Indexes: all 6 present in sqlite_master after init
+- FTS: quoted-token sanitize, hostile inputs raise nothing, symbol-only
+  input returns [], real query still matches correct sermon
+- Favorite: 0 FTS rebuilds on is_favorite/notes updates, exactly 1 on title
+- UTC: created_at/updated_at delta < 5s in raw row; fresh llm row counted
+  by get_llm_usage_summary(days=30); 40d-old llm row pruned
+- Persistence: transcript absent from background_jobs.result JSON, small
+  fields intact; executor trim verified
+- Clear Completed removes completed+failed+cancelled, keeps queued/running
+- prune_old_jobs: stale terminal row dropped from db+memory, recent kept,
+  old queued kept
+- Singleton: 8 concurrent get_job_queue threads -> one instance
+- pytest tests/: 30 passed; ruff clean on all four files; CRLF preserved in
+  job_queue.py and job_executors.py

--- a/scripts/migrate_db.py
+++ b/scripts/migrate_db.py
@@ -23,12 +23,43 @@ CHILD_TABLES = (
     'processing_status',
 )
 
+# Must match the indexes created by SermonDatabase.init_database()
+INDEX_STATEMENTS = (
+    ("idx_llm_usage_timestamp", "llm_api_usage(timestamp)"),
+    ("idx_llm_usage_provider_model", "llm_api_usage(provider, model)"),
+    ("idx_llm_usage_sermon_id", "llm_api_usage(sermon_id)"),
+    ("idx_qa_segments_sermon_id", "qa_segments(sermon_id)"),
+    ("idx_processing_status_sermon_operation",
+     "processing_status(sermon_id, operation)"),
+    ("idx_processing_status_started_at", "processing_status(started_at)"),
+    ("idx_sermons_status", "sermons(status)"),
+    ("idx_sermons_recorded_date", "sermons(recorded_date)"),
+)
+
 
 def _connect(db_path: Path) -> sqlite3.Connection:
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA foreign_keys = ON")
     return conn
+
+
+def enable_wal(conn: sqlite3.Connection) -> None:
+    """Switch the database to write-ahead logging (persistent per file)."""
+    mode = conn.execute("PRAGMA journal_mode = WAL").fetchone()[0]
+    print(f"Journal mode: {mode}")
+
+
+def ensure_indexes(conn: sqlite3.Connection) -> None:
+    """Create any missing query indexes."""
+    created = 0
+    for name, columns in INDEX_STATEMENTS:
+        cursor = conn.execute(
+            f"CREATE INDEX IF NOT EXISTS {name} ON {columns}"
+        )
+        created += max(cursor.rowcount, 0)
+    conn.commit()
+    print(f"Indexes ensured ({created} created)")
 
 
 def rebuild_fts(conn: sqlite3.Connection) -> None:
@@ -126,6 +157,8 @@ def main() -> int:
         dedupe_fts(conn)
         remove_orphans(conn, tables)
         guard_null_dates(conn)
+        ensure_indexes(conn)
+        enable_wal(conn)
         print("Database repair complete")
     finally:
         conn.close()

--- a/ui/database.py
+++ b/ui/database.py
@@ -32,6 +32,16 @@ def _resolve_database_url(db_path: str) -> str:
     return db_path
 
 
+def utcnow() -> datetime.datetime:
+    """Naive UTC timestamp used for every explicit database write and comparison.
+
+    SQLite's CURRENT_TIMESTAMP defaults store UTC, so explicit writes must
+    also be UTC or timestamp math mixes wall-clock-local and UTC values.
+    The naive format keeps parity with rows written by older versions.
+    """
+    return datetime.datetime.now(datetime.UTC).replace(tzinfo=None)
+
+
 class SermonDatabase:
     """SQLite database for sermon metadata and processing status"""
 
@@ -44,8 +54,13 @@ class SermonDatabase:
         self.init_database()
 
     def init_database(self):
-        """Initialize database tables"""
+        """Initialize database tables (and enable WAL journaling)"""
         with self.get_connection() as conn:
+            # WAL lets readers work while a worker writes; the mode is stored
+            # in the database file, so setting it once here covers all later
+            # connections.
+            conn.execute("PRAGMA journal_mode = WAL")
+
             # Config cache table (survives reboots, no expiration)
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS config_cache (
@@ -308,6 +323,36 @@ class SermonDatabase:
                 ON llm_api_usage(provider, model)
             """)
 
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_llm_usage_sermon_id
+                ON llm_api_usage(sermon_id)
+            """)
+
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_qa_segments_sermon_id
+                ON qa_segments(sermon_id)
+            """)
+
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_processing_status_sermon_operation
+                ON processing_status(sermon_id, operation)
+            """)
+
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_processing_status_started_at
+                ON processing_status(started_at)
+            """)
+
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_sermons_status
+                ON sermons(status)
+            """)
+
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_sermons_recorded_date
+                ON sermons(recorded_date)
+            """)
+
             conn.commit()
 
     @contextmanager
@@ -323,13 +368,13 @@ class SermonDatabase:
 
     def cache_metadata(self, key: str, data: list[str], expires_hours: int = 24):
         """Cache metadata with expiration"""
-        expires_at = datetime.datetime.now() + datetime.timedelta(hours=expires_hours)
+        expires_at = utcnow() + datetime.timedelta(hours=expires_hours)
 
         with self.get_connection() as conn:
             conn.execute("""
                 INSERT OR REPLACE INTO metadata_cache (key, data, last_updated, expires_at)
                 VALUES (?, ?, ?, ?)
-            """, (key, json.dumps(data), datetime.datetime.now(), expires_at))
+            """, (key, json.dumps(data), utcnow(), expires_at))
             conn.commit()
 
     @staticmethod
@@ -358,7 +403,7 @@ class SermonDatabase:
                 return None
 
             expires_at = self._parse_db_timestamp(row['expires_at'])
-            is_stale = expires_at is not None and expires_at <= datetime.datetime.now()
+            is_stale = expires_at is not None and expires_at <= utcnow()
             return {
                 'data': json.loads(row['data']),
                 'last_updated': self._parse_db_timestamp(row['last_updated']),
@@ -381,7 +426,7 @@ class SermonDatabase:
             conn.execute("""
                 INSERT OR REPLACE INTO config_cache (key, data, updated_at)
                 VALUES (?, ?, ?)
-            """, ("app_config", json.dumps(config), datetime.datetime.now()))
+            """, ("app_config", json.dumps(config), utcnow()))
             conn.commit()
 
     def load_config(self) -> dict | None:
@@ -396,12 +441,12 @@ class SermonDatabase:
 
     def cache_api_response(self, cache_key: str, data: dict, expires_hours: int = 24) -> None:
         """Cache an API response in the database."""
-        expires_at = datetime.datetime.now() + datetime.timedelta(hours=expires_hours)
+        expires_at = utcnow() + datetime.timedelta(hours=expires_hours)
         with self.get_connection() as conn:
             conn.execute("""
                 INSERT OR REPLACE INTO api_cache (cache_key, data, cached_at, expires_at)
                 VALUES (?, ?, ?, ?)
-            """, (cache_key, json.dumps(data), datetime.datetime.now(), expires_at))
+            """, (cache_key, json.dumps(data), utcnow(), expires_at))
             conn.commit()
 
     def get_cached_api_response(self, cache_key: str) -> dict | None:
@@ -410,7 +455,7 @@ class SermonDatabase:
             row = conn.execute("""
                 SELECT data FROM api_cache
                 WHERE cache_key = ? AND (expires_at IS NULL OR expires_at > ?)
-            """, (cache_key, datetime.datetime.now())).fetchone()
+            """, (cache_key, utcnow())).fetchone()
             if row:
                 return json.loads(row['data'])
             return None
@@ -419,14 +464,14 @@ class SermonDatabase:
         """Clear all expired API cache entries."""
         with self.get_connection() as conn:
             conn.execute("DELETE FROM api_cache WHERE expires_at < ?",
-                        (datetime.datetime.now(),))
+                        (utcnow(),))
             conn.commit()
 
     def update_processing_status(self, sermon_id: str, operation: str,
                                status: str, progress: float = 0.0,
                                message: str = ""):
         """Update processing status for a sermon"""
-        now = datetime.datetime.now()
+        now = utcnow()
 
         with self.get_connection() as conn:
             # Check if record exists
@@ -488,7 +533,7 @@ class SermonDatabase:
                 VALUES (?, ?, ?, ?, ?, ?, ?)
             """, (sermon_id, is_valid, score, reason,
                   json.dumps(criteria_met), json.dumps(criteria_failed),
-                  datetime.datetime.now()))
+                  utcnow()))
             conn.commit()
 
     def get_validation_results(self, sermon_ids: list[str] = None) -> list[dict]:
@@ -522,7 +567,7 @@ class SermonDatabase:
             conn.execute("""
                 INSERT INTO manual_review (sermon_id, reason, status, created_at)
                 VALUES (?, ?, 'pending', ?)
-            """, (sermon_id, reason, datetime.datetime.now()))
+            """, (sermon_id, reason, utcnow()))
             conn.commit()
 
     def get_manual_reviews(self, status: str = None) -> list[dict]:
@@ -546,24 +591,27 @@ class SermonDatabase:
                 UPDATE manual_review
                 SET status = ?, reviewed_at = ?, notes = ?
                 WHERE id = ?
-            """, (status, datetime.datetime.now(), notes, review_id))
+            """, (status, utcnow(), notes, review_id))
             conn.commit()
 
     def cleanup_old_records(self, days: int = 30):
-        """Clean up old processing status and expired cache entries"""
-        cutoff = datetime.datetime.now() - datetime.timedelta(days=days)
+        """Clean up old processing status, LLM usage rows, and expired cache entries"""
+        cutoff = utcnow() - datetime.timedelta(days=days)
 
         with self.get_connection() as conn:
             # Clean old processing status
             conn.execute("DELETE FROM processing_status WHERE started_at < ?", (cutoff,))
 
+            # Clean old LLM usage rows (they store full prompts and responses)
+            conn.execute("DELETE FROM llm_api_usage WHERE timestamp < ?", (cutoff,))
+
             # Clean expired metadata cache
             conn.execute(
-                "DELETE FROM metadata_cache WHERE expires_at < ?", (datetime.datetime.now(),)
+                "DELETE FROM metadata_cache WHERE expires_at < ?", (utcnow(),)
             )
 
             conn.commit()
-            logger.info("Cleaned up old database records")
+            logger.info(f"Cleaned up database records older than {days} days")
 
     def log_llm_api_usage(self, sermon_id: str = None, operation: str = "",
                           provider: str = "", model: str = "",
@@ -592,7 +640,7 @@ class SermonDatabase:
 
     def get_llm_usage_summary(self, days: int = 30):
         """Get LLM usage summary for the specified number of days"""
-        cutoff = datetime.datetime.now() - datetime.timedelta(days=days)
+        cutoff = utcnow() - datetime.timedelta(days=days)
 
         with self.get_connection() as conn:
             # Total usage stats
@@ -661,7 +709,7 @@ class SermonDatabase:
 
     def get_llm_usage_by_operation(self, days: int = 30):
         """Get LLM usage breakdown by operation type"""
-        cutoff = datetime.datetime.now() - datetime.timedelta(days=days)
+        cutoff = utcnow() - datetime.timedelta(days=days)
 
         with self.get_connection() as conn:
             operations = conn.execute("""
@@ -709,6 +757,22 @@ def _fts_snippet_case() -> str:
         whens.append(f"WHEN instr({snippet}, '<mark>') > 0 THEN {snippet}")
     fallback = "snippet(sermon_search, 3, '<mark>', '</mark>', '...', 32)"
     return "CASE " + " ".join(whens) + f" ELSE {fallback} END"
+
+
+def sanitize_fts_query(query_text: str) -> str:
+    """Convert raw user input into quoted FTS5 tokens joined by implicit AND.
+
+    Double quotes are escaped by doubling them so arbitrary input cannot
+    break MATCH syntax; tokens without any alphanumeric character are
+    dropped so symbol-only input yields an empty (skip-search) query.
+    """
+    tokens = []
+    for raw in str(query_text or '').split():
+        if not any(ch.isalnum() for ch in raw):
+            continue
+        token = raw.replace('"', '""')
+        tokens.append(f'"{token}"')
+    return ' '.join(tokens)
 
 
 def _like_snippet(row: sqlite3.Row, query_text: str) -> str:
@@ -818,7 +882,7 @@ class SermonRepository:
                     sermon_data.get('description'),
                     sermon_data.get('duration'),
                     sermon_data.get('status', 'processed'),
-                    datetime.datetime.now()
+                    utcnow()
                 ))
 
                 # Save file paths
@@ -1030,7 +1094,7 @@ class SermonRepository:
                         params.append(metadata[col])
                 if set_parts:
                     set_parts.append("updated_at = ?")
-                    params.append(datetime.datetime.now())
+                    params.append(utcnow())
                     params.append(sermon_id)
                     conn.execute(f"""
                         UPDATE sermons SET {', '.join(set_parts)} WHERE id = ?
@@ -1049,9 +1113,14 @@ class SermonRepository:
                             {set_expr},
                             updated_at = excluded.updated_at
                     """, [sermon_id] + [metadata[c] for c in content_updates]
-                         + [datetime.datetime.now()])
+                         + [utcnow()])
 
-                if set_parts or content_updates:
+                # Rebuild the FTS row only when an indexed column changed, so
+                # toggles like is_favorite or notes edits stay cheap.
+                needs_fts_rebuild = (
+                    bool({'title', 'speaker'} & set(metadata)) or bool(content_updates)
+                )
+                if needs_fts_rebuild:
                     self._rebuild_fts_row(conn, sermon_id)
 
                 conn.commit()
@@ -1127,6 +1196,10 @@ class SermonRepository:
     def search_sermons(self, query_text: str, limit: int = 50) -> list[dict[str, Any]]:
         """Full-text search across sermon content"""
         with self.db.get_connection() as conn:
+            sanitized_query = sanitize_fts_query(query_text)
+            if not sanitized_query:
+                return []
+
             # Try FTS search first, fall back to LIKE search if FTS fails
             try:
                 search_results = conn.execute(f"""
@@ -1139,7 +1212,7 @@ class SermonRepository:
                     WHERE sermon_search MATCH ?
                     ORDER BY rank
                     LIMIT ?
-                """, (query_text, limit)).fetchall()
+                """, (sanitized_query, limit)).fetchall()
             except Exception:
                 # Fallback to simple LIKE search if FTS fails
                 like_rows = conn.execute("""
@@ -1221,7 +1294,7 @@ class SermonRepository:
 
                 if set_clauses:
                     set_clauses.append("updated_at = ?")
-                    params.append(datetime.datetime.now())
+                    params.append(utcnow())
                     params.append(sermon_id)
 
                     query = f"UPDATE sermons SET {', '.join(set_clauses)} WHERE id = ?"
@@ -1246,7 +1319,7 @@ class SermonRepository:
                             {set_expr},
                             updated_at = excluded.updated_at
                     """, [sermon_id] + list(content_updates.values())
-                         + [datetime.datetime.now()])
+                         + [utcnow()])
 
                 if set_clauses or content_updates:
                     self._rebuild_fts_row(conn, sermon_id)

--- a/ui/job_executors.py
+++ b/ui/job_executors.py
@@ -20,6 +20,15 @@ from job_queue import Job, JobCancelledError, JobResult, JobStatus, JobType  # n
 
 logger = logging.getLogger(__name__)
 
+# Bulky result keys that are stored elsewhere (sermon_content) and must not
+# be copied into job results, which persist to the jobs table
+_RESULT_TRIM_FIELDS = ('transcript',)
+
+
+def _trim_result_payload(result: dict) -> dict:
+    """Return a shallow copy of a processing result without bulky fields."""
+    return {k: v for k, v in result.items() if k not in _RESULT_TRIM_FIELDS}
+
 
 def _inject_sermon_updater_config(config: dict) -> None:
     """Inject config into the sermon_updater module so its module-level
@@ -432,7 +441,7 @@ def execute_sermon_processing_job(job: Job) -> JobResult:
             return JobResult(
                 success=True,
                 message=f"Sermon processed successfully: {sermon_id or 'dry run'}",
-                data=result,
+                data=_trim_result_payload(result),
             )
         else:
             err = result.get('error') or 'Unknown processing error'
@@ -441,7 +450,7 @@ def execute_sermon_processing_job(job: Job) -> JobResult:
                 success=False,
                 message=f"Processing failed: {err}",
                 error=err,
-                data=result,
+                data=_trim_result_payload(result),
             )
 
     except JobCancelledError:

--- a/ui/job_queue.py
+++ b/ui/job_queue.py
@@ -21,7 +21,7 @@ import time
 import uuid
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -37,6 +37,12 @@ logger = logging.getLogger(__name__)
 
 _SECRET_KEY_SUFFIXES = ('_key', '_token', '_secret', '_password', '_passwd')
 _SECRET_KEY_NAMES = frozenset({'password', 'passwd', 'token', 'secret', 'auth', 'authorization'})
+
+# Result payload keys that are too bulky to persist with every job record
+_RESULT_STRIP_FIELDS = frozenset({'transcript'})
+
+# Terminal jobs older than this are pruned from memory and the database
+JOB_RETENTION_DAYS = 30
 
 
 def _is_secret_key(key: str) -> bool:
@@ -81,6 +87,11 @@ class JobStatus(Enum):
 
 class JobCancelledError(Exception):
     """Raised when a job is cancelled while it is executing."""
+
+
+_TERMINAL_JOB_STATUSES = frozenset({
+    JobStatus.COMPLETED, JobStatus.FAILED, JobStatus.CANCELLED,
+})
 
 
 @dataclass
@@ -157,6 +168,20 @@ class Job:
         return cls(**data)
 
 
+def _result_for_persistence(result: JobResult) -> dict[str, Any]:
+    """Serialize a JobResult without bulky payload fields (e.g. transcripts).
+
+    Transcripts can be megabytes of text and are already stored in
+    sermon_content; keeping them in background_jobs.result bloats the
+    database forever since job rows have no size bound.
+    """
+    data = asdict(result)
+    payload = data.get('data')
+    if isinstance(payload, dict):
+        data['data'] = {k: v for k, v in payload.items() if k not in _RESULT_STRIP_FIELDS}
+    return data
+
+
 class JobQueue:
     """Thread-safe job queue manager"""
 
@@ -211,6 +236,9 @@ class JobQueue:
         self._running = True
         self._shutdown_event.clear()
 
+        # Prune terminal jobs past the retention window before loading
+        self.prune_old_jobs()
+
         # Load existing jobs from database
         self._load_jobs_from_db()
 
@@ -237,7 +265,7 @@ class JobQueue:
         because _get_next_job() only looks for QUEUED status. Mark them
         as FAILED so the user can review and retry from the Jobs page.
         """
-        recovered = 0
+        recovered_jobs = []
         with self._queue_lock:
             for job in self._jobs.values():
                 if job.status == JobStatus.RUNNING:
@@ -249,14 +277,58 @@ class JobQueue:
                         message="Service restarted during processing",
                         error="Job was interrupted by a service restart. Please retry.",
                     )
-                    self._save_job_to_db(job)
-                    recovered += 1
+                    recovered_jobs.append(job)
 
-        if recovered:
+        for job in recovered_jobs:
+            self._save_job_to_db(job)
+
+        if recovered_jobs:
             logger.warning(
-                f"Recovered {recovered} orphaned job(s) left in RUNNING state "
+                f"Recovered {len(recovered_jobs)} orphaned job(s) left in RUNNING state "
                 f"from a previous restart. Marked as FAILED — retry from the Jobs page."
             )
+
+    def prune_old_jobs(self, days: int = JOB_RETENTION_DAYS) -> int:
+        """Delete terminal jobs older than the retention window.
+
+        Removes completed/failed/cancelled jobs whose completed_at predates
+        the cutoff from both the database and the in-memory dict, so startup
+        never reloads an unbounded history of job rows.
+        """
+        if not self.db:
+            return 0
+
+        cutoff = (datetime.now() - timedelta(days=days)).isoformat()
+        status_values = [status.value for status in _TERMINAL_JOB_STATUSES]
+        placeholders = ','.join(['?' for _ in status_values])
+        removed = 0
+
+        try:
+            with self.db.get_connection() as conn:
+                cursor = conn.execute(f"""
+                    DELETE FROM background_jobs
+                    WHERE status IN ({placeholders})
+                      AND completed_at IS NOT NULL AND completed_at < ?
+                """, (*status_values, cutoff))
+                conn.commit()
+                removed = max(cursor.rowcount, 0)
+        except Exception as e:
+            logger.error(f"Failed to prune old jobs from database: {e}")
+
+        with self._queue_lock:
+            stale_ids = [
+                job_id for job_id, job in self._jobs.items()
+                if job.status in _TERMINAL_JOB_STATUSES
+                and job.completed_at is not None
+                and job.completed_at.isoformat() < cutoff
+            ]
+            for job_id in stale_ids:
+                del self._jobs[job_id]
+
+        if removed or stale_ids:
+            logger.info(f"Pruned {removed} database / {len(stale_ids)} memory "
+                        f"job(s) older than {days} days")
+        return removed
 
     def stop(self):
         """Stop the job queue"""
@@ -291,9 +363,13 @@ class JobQueue:
             priority=priority
         )
 
+        # Persist before publishing to the queue so workers only ever see a
+        # job whose initial state is already durable, and so the SQLite write
+        # never happens under the queue lock.
+        self._save_job_to_db(job)
+
         with self._queue_lock:
             self._jobs[job_id] = job
-            self._save_job_to_db(job)
 
         job.add_log(f"Job created: {title}")
         logger.info(f"Added job {job_id}: {title}")
@@ -319,68 +395,68 @@ class JobQueue:
 
     def cancel_job(self, job_id: str) -> bool:
         """Cancel a job"""
+        cancelled = False
         with self._queue_lock:
             job = self._jobs.get(job_id)
-            if not job or not job.can_cancel:
-                return False
+            if job and job.can_cancel:
+                if job.status in [JobStatus.QUEUED, JobStatus.RUNNING]:
+                    job.cancelled = True
+                    job.status = JobStatus.CANCELLED
+                    job.completed_at = datetime.now()
+                    job.add_log("Job cancelled by user")
+                    cancelled = True
+                    logger.info(f"Cancelled job {job_id}")
 
-            if job.status in [JobStatus.QUEUED, JobStatus.RUNNING]:
-                job.cancelled = True
-                job.status = JobStatus.CANCELLED
-                job.completed_at = datetime.now()
-                job.add_log("Job cancelled by user")
-                self._save_job_to_db(job)
-                logger.info(f"Cancelled job {job_id}")
-                return True
-
-        return False
+        if cancelled:
+            self._save_job_to_db(job)
+        return cancelled
 
     def retry_job(self, job_id: str) -> bool:
         """Retry a failed, cancelled, or completed job"""
+        retried = False
         with self._queue_lock:
             job = self._jobs.get(job_id)
-            if not job or not job.can_retry:
-                return False
+            if job and job.can_retry:
+                if job.status in [JobStatus.FAILED, JobStatus.CANCELLED, JobStatus.COMPLETED]:
+                    job.cancelled = False
+                    job.status = JobStatus.QUEUED
+                    job.progress = 0.0
+                    job.started_at = None
+                    job.completed_at = None
+                    job.result = None
+                    job.add_log("Job queued for retry")
+                    retried = True
+                    logger.info(f"Retrying job {job_id}")
 
-            if job.status in [JobStatus.FAILED, JobStatus.CANCELLED, JobStatus.COMPLETED]:
-                job.cancelled = False
-                job.status = JobStatus.QUEUED
-                job.progress = 0.0
-                job.started_at = None
-                job.completed_at = None
-                job.result = None
-                job.add_log("Job queued for retry")
-                self._save_job_to_db(job)
-                logger.info(f"Retrying job {job_id}")
-                return True
-
-        return False
+        if retried:
+            self._save_job_to_db(job)
+        return retried
 
     def clear_completed_jobs(self) -> int:
-        """Remove completed jobs from queue"""
+        """Remove terminal jobs (completed, cancelled, failed) from queue"""
         removed_count = 0
         with self._queue_lock:
-            completed_jobs = [
+            cleared_ids = [
                 job_id for job_id, job in self._jobs.items()
-                if job.status in [JobStatus.COMPLETED, JobStatus.CANCELLED]
+                if job.status in _TERMINAL_JOB_STATUSES
             ]
 
-            for job_id in completed_jobs:
+            for job_id in cleared_ids:
                 del self._jobs[job_id]
                 removed_count += 1
 
-            # Also remove from database
-            if self.db and completed_jobs:
-                try:
-                    with self.db.get_connection() as conn:
-                        placeholders = ','.join(['?' for _ in completed_jobs])
-                        conn.execute(
-                            f"DELETE FROM background_jobs WHERE id IN ({placeholders})",
-                            completed_jobs
-                        )
-                        conn.commit()
-                except Exception as e:
-                    logger.error(f"Failed to clear completed jobs from database: {e}")
+        # Also remove from database
+        if self.db and cleared_ids:
+            try:
+                with self.db.get_connection() as conn:
+                    placeholders = ','.join(['?' for _ in cleared_ids])
+                    conn.execute(
+                        f"DELETE FROM background_jobs WHERE id IN ({placeholders})",
+                        cleared_ids
+                    )
+                    conn.commit()
+            except Exception as e:
+                logger.error(f"Failed to clear completed jobs from database: {e}")
 
         logger.info(f"Cleared {removed_count} completed jobs")
         return removed_count
@@ -422,9 +498,9 @@ class JobQueue:
             next_job.status = JobStatus.RUNNING
             next_job.started_at = datetime.now()
             next_job.add_log("Job started")
-            self._save_job_to_db(next_job)
 
-            return next_job
+        self._save_job_to_db(next_job)
+        return next_job
 
     def _mark_cancelled(self, job: Job):
         """Mark a job as cancelled and record its completion time."""
@@ -517,7 +593,7 @@ class JobQueue:
                     job.id, job.type.value, job.title, job.description,
                     job.status.value, job.progress,
                     parameters_json,
-                    json.dumps(asdict(job.result)) if job.result else None,
+                    json.dumps(_result_for_persistence(job.result)) if job.result else None,
                     json.dumps(job.logs) if job.logs else None,
                     job.created_at.isoformat() if job.created_at else None,
                     job.started_at.isoformat() if job.started_at else None,
@@ -588,14 +664,16 @@ class JobQueue:
 
 # Global job queue instance
 _job_queue: JobQueue | None = None
+_job_queue_lock = threading.Lock()
 
 
 def get_job_queue() -> JobQueue:
     """Get the global job queue instance"""
     global _job_queue
-    if _job_queue is None:
-        _job_queue = JobQueue()
-        _job_queue.start()
+    with _job_queue_lock:
+        if _job_queue is None:
+            _job_queue = JobQueue()
+            _job_queue.start()
     return _job_queue
 
 
@@ -609,7 +687,8 @@ def initialize_job_queue():
 def shutdown_job_queue():
     """Shutdown the job queue system"""
     global _job_queue
-    if _job_queue:
-        _job_queue.stop()
-        _job_queue = None
-        logger.info("Job queue system shutdown")
+    with _job_queue_lock:
+        if _job_queue:
+            _job_queue.stop()
+            _job_queue = None
+            logger.info("Job queue system shutdown")


### PR DESCRIPTION
Fixes #145, #146, #159: transcripts stripped from persisted job results; 30-day retention for terminal jobs and llm_api_usage rows; Clear Completed covers failed jobs too; WAL journal mode; thread-safe queue singleton; lock scope minimized around SQLite writes; UTC timestamps standardized; FTS queries sanitized against injection-driven LIKE fallbacks; six missing indexes added; favorite toggle no longer rebuilds the whole FTS row. 32/32 ad-hoc verifications, 30 tests passing. Fixes #145, fixes #146, fixes #159. Part of #45.