### PR TITLE
fix: unify db module imports, widen update_sermon whitelist; docs env truth

### DIFF
--- a/docs/SECURITY_SETUP_GUIDE.md
+++ b/docs/SECURITY_SETUP_GUIDE.md
@@ -74,9 +74,7 @@ See `.env.example` for the complete list of available environment variables. Key
 #### LLM Providers (Configure at least one)
 - `OPENAI_API_KEY` - OpenAI GPT models
 - `XAI_API_KEY` - xAI Grok models
-- `ANTHROPIC_API_KEY` - Anthropic Claude models
 - `GROQ_API_KEY` - Groq fast inference
-- `GOOGLE_API_KEY` - Google Gemini models
 - `OPENROUTER_API_KEY` - OpenRouter models
 
 #### Local LLM (Alternative to API providers)

--- a/ui/analytics_manager.py
+++ b/ui/analytics_manager.py
@@ -31,7 +31,7 @@ except ImportError:
             pass
     sermonaudio = MockSermonAudio()
 
-from database import SermonRepository  # noqa: E402
+from ui.database import SermonRepository  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/ui/config_utils.py
+++ b/ui/config_utils.py
@@ -32,7 +32,7 @@ def load_config_from_file():
 
         # Prefer settings saved in the database (survives container recreation)
         try:
-            from database import SermonDatabase
+            from ui.database import SermonDatabase
 
             db = SermonDatabase()
             db_config = db.load_config()
@@ -50,7 +50,7 @@ def load_config_from_file():
         else:
             # Try loading from database cache (survives Docker/git resets)
             try:
-                from database import SermonDatabase
+                from ui.database import SermonDatabase
 
                 db = SermonDatabase()
                 config = db.load_config()
@@ -177,7 +177,7 @@ def save_config_to_file(config):
 
         # Also save to database so settings survive config.yaml loss (Docker, git, etc.)
         try:
-            from database import SermonDatabase
+            from ui.database import SermonDatabase
 
             db = SermonDatabase()
             db.save_config(config)

--- a/ui/database.py
+++ b/ui/database.py
@@ -1283,8 +1283,9 @@ class SermonRepository:
 
                 # Main sermon table fields
                 sermon_fields = [
-                    'title', 'speaker', 'recorded_date', 'event_type', 'bible_text',
-                    'duration', 'status',
+                    'title', 'subtitle', 'speaker', 'recorded_date', 'event_type',
+                    'bible_text', 'series_title', 'description', 'scripture_reference',
+                    'church_name', 'is_favorite', 'notes', 'duration', 'status',
                 ]
 
                 for field in sermon_fields:

--- a/ui/job_executors.py
+++ b/ui/job_executors.py
@@ -259,8 +259,9 @@ def execute_sermon_import_job(job: Job) -> JobResult:
         )
 
         # Import sermon importer
-        from database import SermonRepository
         from sermon_importer import SermonImporter
+
+        from ui.database import SermonRepository
 
         importer = SermonImporter(processed_sermons_dir)
         repo = SermonRepository()

--- a/ui/job_queue.py
+++ b/ui/job_queue.py
@@ -199,7 +199,7 @@ class JobQueue:
     def _init_database(self):
         """Initialize job storage in database"""
         try:
-            from database import get_db
+            from ui.database import get_db
             self.db = get_db()
 
             # Create jobs table if it doesn't exist

--- a/ui/sermon_importer.py
+++ b/ui/sermon_importer.py
@@ -19,9 +19,8 @@ src_dir = ui_dir.parent / "src"
 sys.path.insert(0, str(ui_dir))
 sys.path.insert(0, str(src_dir))
 
-from database import SermonRepository  # noqa: E402
-
 from src.sermon_paths import FILENAMES, discover_sermons, read_metadata  # noqa: E402
+from ui.database import SermonRepository  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/ui/sermon_manager.py
+++ b/ui/sermon_manager.py
@@ -33,9 +33,9 @@ except ImportError:
     sermonaudio = MockSermonAudio()
 
 import yaml  # noqa: E402
-from database import SermonRepository  # noqa: E402
 
 from src.sermon_paths import discover_sermons, read_metadata  # noqa: E402
+from ui.database import SermonRepository  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/ui/sermon_metadata.py
+++ b/ui/sermon_metadata.py
@@ -78,7 +78,7 @@ def get_cached_metadata() -> dict[str, list[str]]:
         'last_refresh' (datetime or None) and 'stale' (bool) flags.
     """
     try:
-        from database import get_db
+        from ui.database import get_db
         db = get_db()
 
         infos = {key: db.get_cached_metadata_info(key) for key in _METADATA_KEYS}
@@ -129,7 +129,7 @@ def get_cached_metadata() -> dict[str, list[str]]:
 def needs_metadata_refresh() -> bool:
     """True when any metadata key is missing from the cache or expired."""
     try:
-        from database import get_db
+        from ui.database import get_db
         db = get_db()
         for key in _METADATA_KEYS:
             info = db.get_cached_metadata_info(key)
@@ -188,7 +188,7 @@ def fetch_and_cache_metadata(
         progress_callback(1.0, 'Saving to cache...')
 
     try:
-        from database import get_db
+        from ui.database import get_db
         db = get_db()
 
         if pastors:

--- a/ui/sermonaudio_api.py
+++ b/ui/sermonaudio_api.py
@@ -86,7 +86,7 @@ class SermonAudioAPI:
 
         # Fall back to database cache
         try:
-            from database import SermonDatabase
+            from ui.database import SermonDatabase
             db = SermonDatabase()
             data = db.get_cached_api_response(cache_key)
             if data:
@@ -115,7 +115,7 @@ class SermonAudioAPI:
 
         # Also save to database for persistence across container restarts
         try:
-            from database import SermonDatabase
+            from ui.database import SermonDatabase
             db = SermonDatabase()
             db.cache_api_response(cache_key, data, expires_hours=24)
         except Exception as e:
@@ -260,7 +260,7 @@ class SermonAudioAPI:
             logger.error(f"Error clearing filesystem cache: {e}")
 
         try:
-            from database import SermonDatabase
+            from ui.database import SermonDatabase
             db = SermonDatabase()
             db.clear_api_cache()
             logger.info("Cleared database API cache")

--- a/ui/system_status.py
+++ b/ui/system_status.py
@@ -31,7 +31,7 @@ try:
 except ImportError:
     sermonaudio_available = False
 
-from database import SermonRepository  # noqa: E402
+from ui.database import SermonRepository  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/ui/ui_pages/analytics.py
+++ b/ui/ui_pages/analytics.py
@@ -283,7 +283,7 @@ def show_cost_tracking():
             import sys
             from pathlib import Path
             sys.path.insert(0, str(Path(__file__).parent.parent))
-            from database import get_db
+            from ui.database import get_db
 
             db = get_db()
             usage_summary = db.get_llm_usage_summary(days=30)
@@ -625,7 +625,7 @@ def get_real_metrics_data(time_range):
         from datetime import datetime, timedelta
         from pathlib import Path
         sys.path.insert(0, str(Path(__file__).parent.parent))
-        from database import get_db
+        from ui.database import get_db
 
         db = get_db()
         processing_data = db.get_processing_status()
@@ -684,7 +684,7 @@ def get_real_content_data():
         import sys
         from pathlib import Path
         sys.path.insert(0, str(Path(__file__).parent.parent))
-        from database import SermonRepository, get_db
+        from ui.database import SermonRepository, get_db
 
         db = get_db()
         repo = SermonRepository(db)
@@ -841,7 +841,7 @@ def get_real_cost_data():
         import sys
         from pathlib import Path
         sys.path.insert(0, str(Path(__file__).parent.parent))
-        from database import get_db
+        from ui.database import get_db
 
         db = get_db()
 
@@ -953,7 +953,7 @@ def get_real_performance_data():
     except Exception:
         # Fallback to existing database-based metrics if performance monitor fails
         try:
-            from database import get_db
+            from ui.database import get_db
 
             db = get_db()
             processing_data = db.get_processing_status()

--- a/ui/ui_pages/dashboard.py
+++ b/ui/ui_pages/dashboard.py
@@ -40,7 +40,7 @@ def show_quick_stats():
     """Display key metrics from the real database"""
     st.markdown("### Quick Statistics")
     try:
-        from database import SermonRepository
+        from ui.database import SermonRepository
         repo = SermonRepository()
         sermons = repo.get_all_sermons()
     except Exception:
@@ -87,7 +87,7 @@ def show_recent_activity():
     """Show recent sermons from the database"""
     st.markdown("### Recent Activity")
     try:
-        from database import SermonRepository
+        from ui.database import SermonRepository
         repo = SermonRepository()
         sermons = repo.get_all_sermons(limit=10)
     except Exception:

--- a/ui/ui_pages/library.py
+++ b/ui/ui_pages/library.py
@@ -81,7 +81,7 @@ def push_sermon_metadata_to_api(sermon):
                     success = sermon_updater.reupload_media_for_sermon(sermon_id, audio_path)
                     if success:
                         _set_feedback("Media re-uploaded successfully!")
-                        from database import SermonRepository
+                        from ui.database import SermonRepository
                         repo = SermonRepository()
                         repo.update_sermon(sermon_id, {'status': 'processed'})
                     else:
@@ -166,7 +166,7 @@ def generate_ai_content(sermon, gen_description=True, gen_hashtags=True):
         if fetched:
             transcript = fetched
             with st.spinner("Saving fetched transcript to local database..."):
-                from database import SermonRepository
+                from ui.database import SermonRepository
                 repo = SermonRepository()
                 if not repo.update_sermon_metadata(
                     sermon_id, {'transcript_text': transcript}
@@ -297,7 +297,7 @@ def generate_ai_content(sermon, gen_description=True, gen_hashtags=True):
 
         # Save to database
         with st.spinner("Saving to database..."):
-            from database import SermonRepository, get_db
+            from ui.database import SermonRepository, get_db
             repo = SermonRepository()
 
             update_data = {}
@@ -366,7 +366,7 @@ def generate_ai_content(sermon, gen_description=True, gen_hashtags=True):
 
 def _toggle_favorite(sermon_id, current_value):
     """Toggle the favorite status of a sermon"""
-    from database import SermonRepository
+    from ui.database import SermonRepository
     repo = SermonRepository()
     repo.update_sermon_metadata(sermon_id, {'is_favorite': 0 if current_value else 1})
     sermon = repo.get_sermon(sermon_id)
@@ -410,14 +410,14 @@ def _export_json(sermons):
 
 def _save_notes(sermon_id, notes):
     """Save notes for a sermon"""
-    from database import SermonRepository
+    from ui.database import SermonRepository
     repo = SermonRepository()
     repo.update_sermon_metadata(sermon_id, {'notes': notes})
 
 
 def _batch_delete(sermon_ids):
     """Delete multiple sermons — actual deletion, confirmation handled in display_sermon_list"""
-    from database import SermonRepository
+    from ui.database import SermonRepository
     repo = SermonRepository()
     count = 0
     for sid in sermon_ids:
@@ -478,8 +478,9 @@ def show_library():
     st.markdown("Browse and search all processed sermons")
 
     try:
-        from database import SermonRepository
         from sermonaudio_api import SermonAudioAPI
+
+        from ui.database import SermonRepository
 
         repo = SermonRepository()
         api_client = SermonAudioAPI()
@@ -644,7 +645,7 @@ def apply_filters(sermons, search_query, speaker_filter, date_filter, status_fil
     # FTS5 search if query is provided
     if search_query:
         try:
-            from database import SermonRepository
+            from ui.database import SermonRepository
             repo = SermonRepository()
             fts_results = repo.search_sermons(search_query, limit=1000)
             fts_ids = {s['id'] for s in fts_results if s.get('id')}
@@ -961,7 +962,7 @@ def display_sermon_details(sermon):
         c1, c2 = st.columns([1, 5])
         with c1:
             if st.button("Yes, delete", type="primary", key=f"confirm_del_{sermon['id']}"):
-                from database import SermonRepository
+                from ui.database import SermonRepository
                 repo = SermonRepository()
                 if repo.delete_sermon(sermon['id']):
                     file_paths = sermon.get('file_paths', sermon.get('files', {}))
@@ -1068,7 +1069,7 @@ def display_sermon_details(sermon):
             db_updates['subtitle'] = api['subtitle']
         if db_updates:
             try:
-                from database import SermonRepository
+                from ui.database import SermonRepository
                 repo = SermonRepository()
                 repo.update_sermon_metadata(sermon_id, db_updates)
             except Exception:
@@ -1225,8 +1226,9 @@ def display_sermon_details(sermon):
                     "Start Re-processing", type="primary", key=f"rp_start_{sermon['id']}"
                 ):
                     try:
-                        from database import SermonRepository
                         from job_queue import JobType, get_job_queue
+
+                        from ui.database import SermonRepository
                         job_queue = get_job_queue()
                         repo = SermonRepository()
                         full_sermon = repo.get_sermon(sermon['id'])
@@ -1276,7 +1278,7 @@ def display_sermon_details(sermon):
             edited_transcript = st.text_area("Edit transcript", value=transcript, height=200)
             save_transcript = st.form_submit_button("Save Transcript", type="primary")
         if save_transcript and edited_transcript != transcript:
-            from database import SermonRepository
+            from ui.database import SermonRepository
             repo = SermonRepository()
             repo.update_sermon(sermon['id'], {'transcript': edited_transcript})
             _set_feedback("Transcript saved")
@@ -1292,7 +1294,7 @@ def display_sermon_details(sermon):
         if save_notes and new_notes != current_notes:
             _save_notes(sermon['id'], new_notes)
             _set_feedback("Notes saved")
-            from database import SermonRepository
+            from ui.database import SermonRepository
             st.session_state.selected_sermon = SermonRepository().get_sermon(sermon['id'])
             st.rerun()
 
@@ -1301,8 +1303,9 @@ def display_sermon_details(sermon):
             "Refresh from SermonAudio", help="Fetch the latest data from SermonAudio API"
         ):
             try:
-                from database import SermonRepository
                 from sermonaudio_api import SermonAudioAPI
+
+                from ui.database import SermonRepository
                 api_client = SermonAudioAPI()
                 fresh_data = api_client.get_sermon_details(sermon_id, force_refresh=True)
                 if fresh_data:

--- a/ui/ui_pages/validation.py
+++ b/ui/ui_pages/validation.py
@@ -833,7 +833,7 @@ def regenerate_description(sermon_id):
 def mark_for_manual_review(sermon_id):
     """Mark sermon for manual review and navigate to library"""
     try:
-        from database import SermonRepository, get_db
+        from ui.database import SermonRepository, get_db
         db = get_db()
         db.add_manual_review(sermon_id, reason="Marked from validation page")
         # Store selected sermon and feedback, then navigate to library
@@ -965,7 +965,7 @@ def show_manual_review():
     st.markdown("### Manual Review Queue")
 
     try:
-        from database import get_db
+        from ui.database import get_db
         db = get_db()
 
         status_filter = st.selectbox(
@@ -1004,7 +1004,7 @@ def show_manual_review():
                     sid = review.get('sermon_id', 'Unknown')
                     st.markdown("**Actions:**")
                     if st.button("Open in Library", key=f"open_review_{review_id}"):
-                        from database import SermonRepository
+                        from ui.database import SermonRepository
                         repo = SermonRepository()
                         sermon = repo.get_sermon(sid)
                         if sermon:

--- a/ui/ui_processor.py
+++ b/ui/ui_processor.py
@@ -20,7 +20,7 @@ src_dir = ui_dir.parent / 'src'
 sys.path.insert(0, str(src_dir))
 sys.path.insert(0, str(ui_dir.parent))
 
-from database import get_db  # noqa: E402
+from ui.database import get_db  # noqa: E402
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fixes #158 remainder + #160: all 41 bare 'from database import' sites standardized to 'from ui.database import' (eliminates duplicate SermonDatabase singletons per process); update_sermon whitelist widened to match update_sermon_metadata (subtitle, series_title, description, scripture_reference, church_name, is_favorite, notes); SECURITY_SETUP_GUIDE env reference aligned with live variables post-provider-cleanup. 30 tests passing. Part of #45.