### PR TITLE
fix: move file info display inside uploaded_file check (NoneType crash)

### DIFF
--- a/ui/ui_pages/new_sermon_enhanced.py
+++ b/ui/ui_pages/new_sermon_enhanced.py
@@ -61,9 +61,6 @@ def _show_upload_section():
             apply_filename_autodetect(uploaded_file.name)
             st.session_state.autodetected_filename = uploaded_file.name
             st.session_state.expand_metadata = True
-    else:
-        st.session_state.pop('uploaded_file', None)
-        st.session_state.pop('expand_metadata', False)
 
         col1, col2, col3, col4 = st.columns(4)
         with col1:
@@ -96,6 +93,9 @@ def _show_upload_section():
                     st.warning(f"Could not preview file: {e}")
         else:
             st.info(f"Preview skipped for files over {max_preview_size // (1024*1024)} MB")
+    else:
+        st.session_state.pop('uploaded_file', None)
+        st.session_state.pop('expand_metadata', False)
 
 
 def _show_metadata_section():


### PR DESCRIPTION
Fixes a pre-existing indentation bug where the file info metrics block (File Size, File Type, File Name, Duration) was indented under the else branch instead of the if uploaded_file branch, causing 'NoneType' object has no attribute 'size' crash whenever no file was uploaded on the New Sermon page. Part of #45.