### PR TITLE
fix: enable Streamlit dark mode

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,6 +1,7 @@
 [theme]
 # Indigo accent so affirmative (type="primary") actions stop rendering
 # Streamlit's default danger-red; matches --card-grad-a in streamlit_app.py.
+base = "dark"
 primaryColor = "#4f46e5"
 
 [server]


### PR DESCRIPTION
Sets base=dark in .streamlit/config.toml. Streamlit only applies dark theme when base is explicitly set; OS preference alone does not activate it. Fixes light-mode-only rendering. One line.